### PR TITLE
Get::Last improvements

### DIFF
--- a/database/install.sh
+++ b/database/install.sh
@@ -46,7 +46,7 @@ function create-user {
 function create-database {
   echo "Database name is: $database"
 
-  database_exists=`psql -tAc "SELECT 1 FROM pg_database WHERE datname='$database'"`
+  database_exists=`psql postgres -tAc "SELECT 1 FROM pg_database WHERE datname='$database'"`
 
   if [ "$database_exists" = "1" ]; then
     echo "Database \"$database\" was previously created. Not creating again."

--- a/lib/event_source/postgres/get/last.rb
+++ b/lib/event_source/postgres/get/last.rb
@@ -13,7 +13,7 @@ module EventSource
         end
 
         def self.configure(receiver, attr_name: nil, session: nil)
-          attr_name ||= :get
+          attr_name ||= :get_last
           instance = build(session: session)
           receiver.public_send "#{attr_name}=", instance
         end

--- a/lib/event_source/postgres/get/last.rb
+++ b/lib/event_source/postgres/get/last.rb
@@ -2,6 +2,7 @@ module EventSource
   module Postgres
     class Get
       class Last
+        include Log::Dependency
 
         dependency :session, Session
 

--- a/lib/event_source/postgres/get/last.rb
+++ b/lib/event_source/postgres/get/last.rb
@@ -2,7 +2,6 @@ module EventSource
   module Postgres
     class Get
       class Last
-        include EventSource::Get
 
         dependency :session, Session
 


### PR DESCRIPTION
This PR fixes three issues I found:

1.`EventSource::Postgres::Get::Last` was including `EventSource::Get`. The problem is that `Get::Last` has an entirely different interface (i.e. it's not substitute of the superclass). Removing the `include EventSource::Get` was no trouble, since all of the generic methods it implements are also implemented in `Get::Last` (with different argument signatures). I did have to add `Log::Dependency`.
2. The default attribute name when configuring `Get::Last` is changed by this PR from `get` to `get_last`.
3. **Not related to `Get::Last`**: The `create-user` bash function was correctly specifying the root `postgres` database, but the `create-database` function was not. This commit was necessary for the install script to run correctly.