### PR TITLE
Log message for select statement no longer raises undefined method error

### DIFF
--- a/lib/event_source/postgres/get/select_statement.rb
+++ b/lib/event_source/postgres/get/select_statement.rb
@@ -14,8 +14,8 @@ module EventSource
           @batch_size ||= Defaults.batch_size
         end
 
-        def stream_type
-          @stream_type ||= StreamName.get_type(stream_name)
+        def stream_type_list
+          @stream_type ||= StreamName.get_type_list(stream_name)
         end
 
         def category_stream?
@@ -27,7 +27,7 @@ module EventSource
         end
 
         def sql
-          logger.trace(tag: :sql) { "Composing select statement (Stream: #{stream_name}, Category: #{category_stream?}, Type: #{stream_type.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
+          logger.trace(tag: :sql) { "Composing select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
 
           statement = <<-SQL
             SELECT
@@ -51,7 +51,7 @@ module EventSource
             ;
           SQL
 
-          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Type: #{stream_type.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
+          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Type: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
           logger.debug(tags: [:data, :sql]) { "Statement: #{statement}" }
 
           statement

--- a/lib/event_source/postgres/get/select_statement.rb
+++ b/lib/event_source/postgres/get/select_statement.rb
@@ -51,7 +51,7 @@ module EventSource
             ;
           SQL
 
-          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Type: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
+          logger.debug(tag: :sql) { "Composed select statement (Stream: #{stream_name}, Category: #{category_stream?}, Types: #{stream_type_list.inspect}, Position: #{position}, Batch Size: #{batch_size})" }
           logger.debug(tags: [:data, :sql]) { "Statement: #{statement}" }
 
           statement


### PR DESCRIPTION
Previously, before we removed `EventSource::StreamName` and replaced it with a postgres specific `EventSource::Postgres::StreamName`, there was a method called `get_type` on `EventSource::StreamName`.

`EventSource::StreamName.get_type` would return the part of the category after the `:`. For instance, `get_type` would return `"command"` if supplied `"account:command-123"`. We later determined that it is very possible to wind up with multiple types, for instance, `"account:command+position"` might store the offset of a consumer that is reading `account:command`. Therefore, there isn't a single type per stream.

All of that is background context; log messages in this library were raising NoMethodError exceptions when the log tags included this library. I updated the messages to use the proper `get_types` module
level method.